### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ langchain-google-vertexai
 openevals
 langgraph-swarm
 langchain-aws
-protobuf>=3.20.3
+protobuf==3.20.3


### PR DESCRIPTION
This fixes the below error during `pip-install`.
Note:  I took a guess you intended `>=`, since `==` can't resolve the dependencies.

```sh
ERROR: Invalid requirement: 'protobuf=3.20.3': Expected end or semicolon (after name and no valid version specifier)
    protobuf=3.20.3
            ^ (from line 26 of requirements.txt)
```